### PR TITLE
status -> response_status so that it aligns with stream configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You need to run at least nginx version 1.11.8, escaped JSON support.
                          '"remote_addr": "$remote_addr", '
                          '"body_bytes_sent": $body_bytes_sent, '
                          '"request_time": $request_time, '
-                         '"status": $status, '
+                         '"response_status": $status, '
                          '"request": "$request", '
                          '"request_method": "$request_method", '
                          '"host": "$host",'


### PR DESCRIPTION
If I use what the README provides as a logging format many of the streams that get configured will fail because they depend on "response_status" instead of "status". This change adjusts the README to match how the streams are configured.